### PR TITLE
Allow individual model references with Backbone.Firebase.Model

### DIFF
--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -333,12 +333,14 @@ Backbone.Firebase.Model = Backbone.Model.extend({
     // Unset attributes that have been deleted from the server
     // by comparing the keys that have been removed.
     var newModel = snap.val();
-    var diff = _.difference(_.keys(this.attributes), _.keys(newModel));
-    var _this = this;
-    _.each(diff, function(key) {
-      _this.unset(key);
-    });
-    this.set(snap.val());
+    if (typeof newModel === "object" && newModel !== null) {
+      var diff = _.difference(_.keys(this.attributes), _.keys(newModel));
+      var _this = this;
+      _.each(diff, function(key) {
+        _this.unset(key);
+      });
+    }
+    this.set(newModel);
     this.trigger('sync', this, null, null);
   },
 

--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -322,6 +322,7 @@ Backbone.Firebase.Model = Backbone.Model.extend({
 
   _modelChanged: function(snap) {
     this.set(snap.val());
+    this.trigger('sync', this, null, null);
   },
 
   _log: function(msg) {

--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -289,7 +289,7 @@ Backbone.Firebase.Model = Backbone.Model.extend({
 
   destroy: function(options) {
     // TODO: Fix naive success callback. Add error callback.
-    this.firebase.set(null);
+    this.firebase.set(null, this._log);
     this.trigger('destroy', this, this.collection, options);
     if (options.success) {
       options.success(this,null,options);
@@ -317,11 +317,11 @@ Backbone.Firebase.Model = Backbone.Model.extend({
   },
 
   _updateModel: function(model, options) {
-      this.firebase.update(model.toJSON());
+      this.firebase.update(model.toJSON(), this._log);
   },
 
   _modelChanged: function(snap) {
-    this.set(snap.val());
+    this.set(snap.val(), {silent:true});
     this.trigger('sync', this, null, null);
   },
 

--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -287,8 +287,10 @@ Backbone.Firebase.Model = Backbone.Model.extend({
     this._log("Save called on a Firebase model, ignoring.");
   },
 
-  destroy: function() {
-    this._log("Destroy called on a Firebase model, ignoring.");
+  destroy: function(options) {
+    // TODO: Implement success and error callbacks.
+    this.firebase.set(null);
+    this.trigger('destroy', this, this.collection, options);
   },
 
   constructor: function(model, options) {
@@ -308,14 +310,21 @@ Backbone.Firebase.Model = Backbone.Model.extend({
     // Add handlers for remote events.
     this.firebase.on("value", this._modelChanged.bind(this));
 
-    function _updateModel(model, options) {
+    this.on("change", this._updateModel, this);
+  },
+
+  _updateModel: function(model, options) {
       this.firebase.update(model.toJSON());
-    }
-    this.on("change", _updateModel, this);
   },
 
   _modelChanged: function(snap) {
     this.set(snap.val());
+  },
+
+  _log: function(msg) {
+    if (console && console.log) {
+      console.log(msg);
+    }
   }
   
 });

--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -297,6 +297,11 @@ Backbone.Firebase.Model = Backbone.Model.extend({
   },
 
   constructor: function(model, options) {
+
+    // Save the keys from the last model so we
+    // can find out which keys have been deleted.
+    this._prevKeys = [];
+
     if (options && options.firebase) {
       this.firebase = options.firebase;
     }
@@ -317,11 +322,21 @@ Backbone.Firebase.Model = Backbone.Model.extend({
   },
 
   _updateModel: function(model, options) {
-      this.firebase.update(model.toJSON(), this._log);
+    // Find the deleted keys and set their values to null
+    // so Firebase properly deletes them
+    var modelJSON, currentKeys, deletedKeys;
+    modelObj = model.toJSON()
+    currentKeys = _.keys(modelObj)
+    deletedKeys = _.difference(this._prevKeys, currentKeys)
+    _.each(deletedKeys, function(key) {
+      modelObj[key] = null;
+    });
+    this.firebase.update(modelObj, this._log);
   },
 
   _modelChanged: function(snap) {
-    this.set(snap.val(), {silent:true});
+    this.set(snap.val());
+    this._prevKeys = _.keys(snap.val());
     this.trigger('sync', this, null, null);
   },
 

--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -343,6 +343,7 @@ Backbone.Firebase.Model = Backbone.Model.extend({
   },
 
   _log: function(msg) {
+    if (typeof msg === "undefined" || msg === null) return;
     if (console && console.log) {
       console.log(msg);
     }

--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -298,10 +298,6 @@ Backbone.Firebase.Model = Backbone.Model.extend({
 
   constructor: function(model, options) {
 
-    // Save the keys from the last model so we
-    // can find out which keys have been deleted.
-    this._prevKeys = [];
-
     if (options && options.firebase) {
       this.firebase = options.firebase;
     }
@@ -324,19 +320,16 @@ Backbone.Firebase.Model = Backbone.Model.extend({
   _updateModel: function(model, options) {
     // Find the deleted keys and set their values to null
     // so Firebase properly deletes them
-    var modelJSON, currentKeys, deletedKeys;
-    modelObj = model.toJSON()
-    currentKeys = _.keys(modelObj)
-    deletedKeys = _.difference(this._prevKeys, currentKeys)
-    _.each(deletedKeys, function(key) {
-      modelObj[key] = null;
+    var modelObj = model.toJSON();
+    _.each(model.changed, function(value, key) {
+      if (value == undefined)
+        modelObj[key] = null;
     });
     this.firebase.update(modelObj, this._log);
   },
 
   _modelChanged: function(snap) {
     this.set(snap.val());
-    this._prevKeys = _.keys(snap.val());
     this.trigger('sync', this, null, null);
   },
 

--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -288,9 +288,12 @@ Backbone.Firebase.Model = Backbone.Model.extend({
   },
 
   destroy: function(options) {
-    // TODO: Implement success and error callbacks.
+    // TODO: Fix naive success callback. Add error callback.
     this.firebase.set(null);
     this.trigger('destroy', this, this.collection, options);
+    if (options.success) {
+      options.success(this,null,options);
+    }
   },
 
   constructor: function(model, options) {


### PR DESCRIPTION
Backbone.Firebase.Model should work transparently in the same way as Backbone.Firebase.Collection

Calling set() on the model will update Firebase, and changes on Firebase will update the model and trigger the appropriate events.

No support for destroy() or the alternative sync method yet.

Bonus: Allow Firebase ref arguments to be a function so you can set dynamic Firebase URLs when creating new models and collections.
