### PR TITLE
Backone 1.0 compatibility

### DIFF
--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -126,9 +126,19 @@ Backbone.Firebase.sync = function(method, model, options, error) {
 
   store[method].apply(this, [model, function(err, val) {
     if (err) {
-      options.error(model, err, options);
+      model.trigger("error", model, err, options);
+      if (Backbone.VERSION === "0.9.10") { 
+        options.error(model, err, options);
+      } else {
+        options.error(err);
+      }
     } else {
-      options.success(model, val, options);
+      model.trigger("sync", model, val, options);
+      if (Backbone.VERSION === "0.9.10") { 
+        options.success(model, val, options);
+      } else {
+        options.success(val);
+      }
     }
   }]);
 };


### PR DESCRIPTION
Looks like there is an undocumented change in Backbone 1.0's sync.

Existing version of backfire just doesn't work, after a while I found that the call back responses parameters changed. 

I made the changes based on similar fix on Backbone.localStorage
https://github.com/jeromegn/Backbone.localStorage/commit/bd34c367442f6854c0d5664425ec04c8108a69fe
