### PR TITLE
Delete is a reselved word and can't be used in IE 8 and below as object key

### DIFF
--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -96,7 +96,7 @@ _.extend(Backbone.Firebase.prototype, {
     });
   },
 
-  delete: function(model, cb) {
+  'delete': function(model, cb) {
     this._fbref.ref().child(model.id).remove(function(err) {
       if (!err) {
         cb(null, model);


### PR DESCRIPTION
This fixes #19
