### PR TITLE
Backbone sync for Firebase model

### DIFF
--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -180,10 +180,6 @@ Backbone.Firebase.sync = function(method, model, options, error) {
   if (method == "read" && model.id == undefined) {
     method = "readAll";
   }
-  
-  if(!store[method]){//it's a firebase object, hopefully
-    store = new Backbone.ModelFirebase(store);
-  }
 
   store[method].apply(this, [model, function(err, val) {
     if (err) {

--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -24,6 +24,9 @@ _.extend(Backbone.ModelFirebase.prototype, {
     model.id = snapshot.name();
     this._model = model;
     this._hasModel = true;
+    while(this._pending.length != 0){
+      _.defer(this._pending.shift(), null, this._model);
+    }
   },
 
   create: function(model, cb){
@@ -36,10 +39,7 @@ _.extend(Backbone.ModelFirebase.prototype, {
     if(this._hasModel){
       _.defer(cb, null, this._model);
     } else {
-      this._fbref.once("value", _.bind(function(snapshot){
-        this._value(snapshot);
-        _.defer(cb, null, this._model);
-      }, this))
+      this._pending.push(cb);
     }
   },
 

--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -26,7 +26,7 @@ Backbone.Firebase = function(ref, isModel) {
     this.read = this._read;
     this.readAll = null;
     this.update = this._update;
-    this.delete = this._delete;
+    this.['delete'] = this._delete;
   } else {
     this._fbref.on("child_added", this._childAdded);
     this._fbref.on("child_moved", this._childMoved);

--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -26,7 +26,7 @@ Backbone.Firebase = function(ref, isModel) {
     this.read = this._read;
     this.readAll = null;
     this.update = this._update;
-    this.['delete'] = this._delete;
+    this['delete'] = this._delete;
   } else {
     this._fbref.on("child_added", this._childAdded);
     this._fbref.on("child_moved", this._childMoved);


### PR DESCRIPTION
Added Backbone.ModelFirebase, which allows for explicit separation between local and remote data when working with individual models. Documentation file has not been updated.

Usage:

``` JavaScript
var todoID = ''; //some ID
var ToDo = Backbone.Model.extend({
  //some things
});
var todoModel = new ToDo({text: 'text'}, {
  firebase: new Backbone.ModelFirebase("https://<your-namespace>.firebaseio.com/" + todoID)
});
```
