### PR TITLE
Limit "looping" remote updates

### DIFF
--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -188,7 +188,10 @@ Backbone.Firebase.Collection = Backbone.Collection.extend({
     // Add handlers for all models in this collection, and any future ones
     // that may be added.
     function _updateModel(model, options) {
-      this.firebase.ref().child(model.id).update(model.toJSON());
+      // If this change is a result of a Firebase push, don't try to re-update Firebase 
+      if (!options.fromFirebase) {
+        this.firebase.ref().child(model.id).update(model.changedAttributes());
+      }
     }
     function _unUpdateModel(model) {
       model.off("change", _updateModel, this);
@@ -296,7 +299,7 @@ Backbone.Firebase.Collection = Backbone.Collection.extend({
       item.unset(key);
     });
 
-    item.set(model);
+    item.set(model, {fromFirebase: true});
   },
 
   _childRemoved: function(snap) {


### PR DESCRIPTION
I noticed some serious problems rapidly writing a large number of changes to multiple models in a Firebase-synched collection when more than one client was accessing the data simultaneously. The changing data from the client actively issuing changes was not always "winning". Instead, many times the passive client would issue interfering changes as a result of being notified of the remote data changes.

Two fixes:
1. Don't update remote data for a model as a result of the local model
   getting updated from the remote data.
2. When updating remote data for a model, only submit the changed
   attributes, not all attributes.
