### PR TITLE
Some updates for underscore >= 1.5.0, fixing the Sync method, and simplifying the Backbone.Collection constructor

### DIFF
--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -190,18 +190,8 @@ Backbone.Firebase.Collection = Backbone.Collection.extend({
     function _updateModel(model, options) {
       this.firebase.ref().child(model.id).update(model.toJSON());
     }
-    function _unUpdateModel(model) {
-      model.off("change", _updateModel, this);
-    }
 
-    for (var i = 0; i < this.models.length; i++) {
-      this.models[i].on("change", _updateModel, this);
-      this.models[i].once("remove", _unUpdateModel, this);
-    }
-    this.on("add", function(model) {
-      model.on("change", _updateModel, this);
-      model.once("remove", _unUpdateModel, this);
-    }, this);
+    this.listenTo(this, 'change', _updateModel, this);
   },
 
   comparator: function(model) {

--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -123,17 +123,17 @@ Backbone.Firebase.sync = function(method, model, options, error) {
     method = "readAll";
   }
 
-  store[method].apply(this, [model, function(err, val) {
+  store[method].apply(store, [model, function(err, val) {
     if (err) {
       model.trigger("error", model, err, options);
-      if (Backbone.VERSION === "0.9.10") { 
+      if (Backbone.VERSION === "0.9.10") {
         options.error(model, err, options);
       } else {
         options.error(err);
       }
     } else {
       model.trigger("sync", model, val, options);
-      if (Backbone.VERSION === "0.9.10") { 
+      if (Backbone.VERSION === "0.9.10") {
         options.success(model, val, options);
       } else {
         options.success(val);

--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -13,11 +13,11 @@ Backbone.Firebase = function(ref) {
   if (typeof ref == "string") {
     this._fbref = new Firebase(ref);
   }
-  _.bindAll(this);
-  this._fbref.on("child_added", this._childAdded);
-  this._fbref.on("child_moved", this._childMoved);
-  this._fbref.on("child_changed", this._childChanged);
-  this._fbref.on("child_removed", this._childRemoved);
+
+  this._fbref.on("child_added", this._childAdded, this);
+  this._fbref.on("child_moved", this._childMoved, this);
+  this._fbref.on("child_changed", this._childChanged, this);
+  this._fbref.on("child_removed", this._childRemoved, this);
 };
 
 _.extend(Backbone.Firebase.prototype, {


### PR DESCRIPTION
I'd been struggling for several hours trying to figure out how to get this Backbone plugin to work. Turns out there were a few items that were my fault (particuarly, not setting my `firebase` property in my model/collection definition to a Backbone.Firebase object, instead of just a Firebase object). But some weren't, this prompted me to comb through the source code to find out what was happening and where things were going wrong under the hood. I found a few things that needed updating:

The `_.bindAll` call in the `Backbone.Firebase` constructor is no longer supported as of underscore 1.5.0 (here: https://github.com/jashkenas/underscore/issues/992, here: https://github.com/jashkenas/underscore/issues/1033, and here: https://github.com/jashkenas/underscore/commit/bf657be243a075b5e72acc8a83e6f12a564d8f55).

The call to `store[method].apply()` in `Backbone.Firebase.sync` sets the incorrect context of `this` instead of `store`.

I also found an improvement that could be made in the `Backbone.Firebase.Collection` constructor in regards to attaching/detaching event listeners for models' `change` events. I went ahead and patched that up to.

Let me know if there are any problems with this PR, I'll be happy to fix them. If you want some but not all of these changes, I'll be glad to submit separate PRs for them if required.

I hope this helps and keeps the next person from spending several hours, many beers (is this really a bad thing?), and lots of frustration trying to figure out what is going on any why things "just don't work."
