### PR TITLE
Apply model defaults

### DIFF
--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -286,9 +286,9 @@ Backbone.Firebase.Collection = Backbone.Collection.extend({
     _.each(diff, function(key) {
       item.unset(key);
     });
-    
+
     item.set(model);
-    
+
     this._preventSync(item, false);
   },
 
@@ -297,17 +297,17 @@ Backbone.Firebase.Collection = Backbone.Collection.extend({
     if (!model.id) model.id = snap.name()
     Backbone.Collection.prototype.remove.apply(this, [model]);
   },
-  
+
   // Add handlers for all models in this collection, and any future ones
   // that may be added.
   _updateModel: function(model, options) {
-  
+
     if (model._remoteChanging) return;
-    
+
     var remoteAttributes = model._remoteAttributes || {};
     var localAttributes = model.toJSON();
     var updateAttributes = {};
-    
+
     _.each(_.union(_.keys(remoteAttributes),_.keys(localAttributes)), function(key) {
       if (!_.has(localAttributes, key)) {
         updateAttributes[key] = null;
@@ -316,15 +316,15 @@ Backbone.Firebase.Collection = Backbone.Collection.extend({
         updateAttributes[key] = localAttributes[key];
       }
     });
-    
+
     if (_.size(updateAttributes)) {
       this.firebase.ref().child(model.id).update(updateAttributes);
     }
   },
-  
+
   _preventSync: function(model, state) {
     model._remoteChanging = state;
-  }  
+  }
 });
 
 // Custom Firebase Model.
@@ -371,11 +371,11 @@ Backbone.Firebase.Model = Backbone.Model.extend({
 
     this._listenLocalChange(true);
   },
-  
+
   _listenLocalChange: function(state) {
     if (state)
       this.on("change", this._updateModel, this);
-    else 
+    else
       this.off("change", this._updateModel, this);
   },
 
@@ -417,7 +417,7 @@ Backbone.Firebase.Model = Backbone.Model.extend({
       console.log(msg);
     }
   }
-  
+
 });
 
 })();

--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -344,6 +344,15 @@ Backbone.Firebase.Model = Backbone.Model.extend({
 
   constructor: function(model, options) {
 
+    // Store defaults so they don't get applied immediately.
+    var defaults = _.result(this, 'defaults');
+    this.defaults = null;
+
+    // Apply defaults only after first sync.
+    this.once('sync', function() {
+      this.set(_.defaults(this.toJSON(), defaults));
+    });
+
     // Apply parent constructor (this will also call initialize).
     Backbone.Model.apply(this, arguments);
 


### PR DESCRIPTION
I'm still new to Firebase, so I'd love some eyes on this. Basically, I noticed that when setting a model's `defaults` property, it would get overwritten by the first server-side sync.

This commit defers setting the default attributes until after the first sync, making sure not to override what's in Firebase.

I also crushed some whitespace. If that hurts your eyes, you can [view this diff without it](https://github.com/firebase/backfire/pull/50/files?w=1).
