### PR TITLE
Use underscore's bind instead of relying on native bind

### DIFF
--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -358,7 +358,7 @@ Backbone.Firebase.Model = Backbone.Model.extend({
     }
 
     // Add handlers for remote events.
-    this.firebase.on("value", this._modelChanged.bind(this));
+    this.firebase.on("value", _.bind(this._modelChanged, this));
 
     this._listenLocalChange(true);
   },


### PR DESCRIPTION
This seems to be the only instance in which `Function.prototype.bind` slipped in. Seems to fail when using a Firebase model in PhantomJS (test runners), which is bizarre.

This fixes that.
