### PR TITLE
Trigger sync after listen is reenabled.

### DIFF
--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -497,8 +497,8 @@
       }
       this._listenLocalChange(false);
       this.set(newModel);
-      this.trigger("sync", this, null, null);
       this._listenLocalChange(true);
+      this.trigger("sync", this, null, null);
     },
 
     _log: function(msg) {


### PR DESCRIPTION
I thought `trigger()` was async, but [apparently it's not](http://backbonejs.org/docs/backbone.html#section-24) :\

This means that when the `sync` event is triggered, any `set()` attributes aren't automatically synced back to Firebase. So basically #50 didn't really fix the issue.
