### PR TITLE
Backbone.Firebase.Model: Fix exception when not passing options

### DIFF
--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -428,7 +428,7 @@
       // TODO: Fix naive success callback. Add error callback.
       this.firebase.ref().set(null, this._log);
       this.trigger("destroy", this, this.collection, options);
-      if (options.success) {
+      if (options && typeof options.success === "function") {
         options.success(this, null, options);
       }
     },


### PR DESCRIPTION
Fix the exception thrown when not passing an options object to the Backbone.Firebase.Model.destroy() function. This reflects the usage shown in the documentation at http://firebase.github.io/backfire/#backbone-firebase-model
