### PR TITLE
Correctly defaulting models when no params are passed to add(), reset()

### DIFF
--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -271,9 +271,6 @@
     },
 
     reset: function(models, options) {
-      if(typeof models === 'undefined'){
-        models = [];
-      }
       options = options ? _.clone(options) : {};
       // Remove all models remotely.
       this.remove(this.models, {silent: true});
@@ -295,7 +292,8 @@
     // TODO: Options will be ignored for add & remove, document this!
     _parseModels: function(models) {
       var ret = [];
-      models = _.isArray(models) ? models.slice() : [models];
+      var singular = !_.isArray(models);
+      models = singular ? (models ? [models] : []) : models.slice();
       for (var i = 0; i < models.length; i++) {
         var model = models[i];
         if (model.toJSON && typeof model.toJSON == "function") {

--- a/backbone-firebase.js
+++ b/backbone-firebase.js
@@ -271,6 +271,9 @@
     },
 
     reset: function(models, options) {
+      if(typeof models === 'undefined'){
+        models = [];
+      }
       options = options ? _.clone(options) : {};
       // Remove all models remotely.
       this.remove(this.models, {silent: true});

--- a/test/specs/collection_test.coffee
+++ b/test/specs/collection_test.coffee
@@ -8,15 +8,14 @@ describe 'Backbone.Firebase.Collection', ->
         expect(@fbCol)
             .to.be.ok
 
-    describe '#reset()', ->
+    describe '#_parseModels()', ->
 
         it 'should be a method', ->
             expect(@fbCol)
-                .to.have.property('reset')
+                .to.have.property('_parseModels')
                 .that.is.a 'function'
 
-        it 'should not throw an error when called without parameters', ->
-            expect( =>
-                @fbCol.reset()
-            ).to.not.throw()
+        it 'should return an empty array when called without parameters', ->
+            result = @fbCol._parseModels()
+            expect(result).to.deep.equal([])
     

--- a/test/specs/collection_test.coffee
+++ b/test/specs/collection_test.coffee
@@ -17,5 +17,5 @@ describe 'Backbone.Firebase.Collection', ->
 
         it 'should return an empty array when called without parameters', ->
             result = @fbCol._parseModels()
-            expect(result).to.deep.equal([])
+            expect(result).to.eql([])
     

--- a/test/specs/collection_test.coffee
+++ b/test/specs/collection_test.coffee
@@ -1,0 +1,22 @@
+describe 'Backbone.Firebase.Collection', ->
+
+    beforeEach ->
+        Col = Backbone.Firebase.Collection.extend model: new Backbone.Model, firebase: new Firebase
+        @fbCol = new Col()
+
+    it 'should exist', ->
+        expect(@fbCol)
+            .to.be.ok
+
+    describe '#reset()', ->
+
+        it 'should be a method', ->
+            expect(@fbCol)
+                .to.have.property('reset')
+                .that.is.a 'function'
+
+        it 'should not throw an error when called without parameters', ->
+            expect( =>
+                @fbCol.reset()
+            ).to.not.throw()
+    


### PR DESCRIPTION
when trying to call reset() without any parameters, backfire would throw an exception. This is because the _parseModels function would create an array of length 1 and attempt to call toJSON() on undefined. I updated _parseModels to default the models parameter correctly.
