### PR TITLE
Upgrade test units to run with latest Karma

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "karma-requirejs": "~0.2.0",
     "karma-coffee-preprocessor": "~0.1.0",
     "karma-phantomjs-launcher": "~0.1.0",
-    "karma": "~0.10.5",
+    "karma": "~0.12.8",
     "chai-backbone": "~0.9.2"
   }
 }

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -69,6 +69,10 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit
-    singleRun: false
+    singleRun: false,
+
+    preprocessors: {
+      '**/*.coffee': ['coffee']
+    }
   });
 };


### PR DESCRIPTION
Running `npm install` failed with errors about Karma peer dependencies and test units would not run.

@oalami please review.
