### PR TITLE
Removed Bacbone.sync override

### DIFF
--- a/src/backfire.js
+++ b/src/backfire.js
@@ -1,20 +1,15 @@
 /*!
  * BackFire is the officially supported Backbone binding for Firebase. The
- * bindings let you use special model and collection types that will
- * automatically synchronize with Firebase, and also allow you to use regular
- * Backbone.Sync based synchronization methods.
+ * bindings let you use special model and collection types that allow for
+ * synchronizing data with Firebase.
  *
- * BackFire 0.0.0
+ * BackFire 0.4.0
  * https://github.com/firebase/backfire/
  * License: MIT
  */
 
-"use strict";
-
-(function() {
-
-  var _ = window._;
-  var Backbone = window.Backbone;
+(function(_, Backbone) {
+  "use strict";
 
   Backbone.Firebase = function(ref) {
     this._fbref = ref;
@@ -125,7 +120,6 @@
     }
   });
 
-
   Backbone.Firebase.sync = function(method, model, options, error) {
     var store = model.firebase || model.collection.firebase;
 
@@ -158,18 +152,6 @@
         }
       }
     }]);
-  };
-
-  Backbone.oldSync = Backbone.sync;
-
-  // Override "Backbone.sync" to default to Firebase sync.
-  // the original "Backbone.sync" is still available in "Backbone.oldSync"
-  Backbone.sync = function(method, model, options, error) {
-    var syncMethod = Backbone.oldSync;
-    if (model.firebase || (model.collection && model.collection.firebase)) {
-      syncMethod = Backbone.Firebase.sync;
-    }
-    return syncMethod.apply(this, [method, model, options, error]);
   };
 
   // Custom Firebase Collection.
@@ -528,4 +510,4 @@
 
   });
 
-})();
+})(window._, window.Backbone);

--- a/test/specs/prototype_test.js
+++ b/test/specs/prototype_test.js
@@ -1,16 +1,23 @@
 describe('Backbone.Firebase', function() {
+
   beforeEach(function() {
     return this.Firebase = new Backbone.Firebase(new Firebase);
   });
+
   it('should exist', function() {
     return expect(this.Firebase).to.be.ok;
   });
+
   it('should create a Firebase reference', function() {
     return expect(this.Firebase._fbref).to.be.an.instanceOf(Firebase);
   });
+
   return describe('#_childAdded()', function() {
+
     return it('should be a method', function() {
       return expect(this.Firebase).to.have.property('_childAdded').that.is.a('function');
     });
+
   });
+
 });


### PR DESCRIPTION
Prior to the 0.4 release a new Backbone.Mode could be created with a `firebase` attribute.

``` javascript
var Todo = Backbone.Model.extend({
   firebase: 'https://<your-firebase>.firebaseio.com/'
});
```

This behavior is being removed in the 0.4 release. The reasoning behind this decision was due to the confusion of the separate components: `Backbone.Firebase.Model` and `Backbone.Model.extend({ firebase: ''});`

Going forward all of the functionality BackFire provides will be in the `Backbone.Firebase` namespace. There will still be an option that allows for data to **not** automatically be synced. In those cases you will be able to call `sync()`, `save()`, `fetch()`, and etc...

This will leave the core of Backbone untouched, while hopefully reducing confusion.
