### PR TITLE
Model once

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,6 +37,6 @@
     "underscore": "~1.5.2"
   },
   "devDependencies": {
-    "jasmine": "~2.0.0"
+    "mockfirebase": "~0.3.0"
   }
 }

--- a/src/backfire.js
+++ b/src/backfire.js
@@ -118,12 +118,12 @@
 
     // Determine whether the realtime or once methods apply
     constructor: function(model, options) {
-      var defaults = _.result(this, 'defaults');
+      //var defaults = _.result(this, 'defaults');
 
       // Apply defaults only after first sync.
-      this.once('sync', function() {
-        this.set(_.defaults(this.toJSON(), defaults));
-      });
+      // this.once('sync', function() {
+      //   this.set(_.defaults(this.toJSON(), defaults));
+      // });
 
       Backbone.Model.apply(this, arguments);
       _.extend(this, { autoSync: true }, options);

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -9,7 +9,7 @@ module.exports = function(config) {
     files: [
       '../bower_components/underscore/underscore.js',
       '../bower_components/backbone/backbone.js',
-      './fixtures.js',
+      '../bower_components/mockfirebase/browser/mockfirebase.js',
       '../src/backfire.js',
       './specs/*_test.js'
     ],

--- a/test/specs/model_test.js
+++ b/test/specs/model_test.js
@@ -1,0 +1,16 @@
+describe('Backbone.Firebase.Model', function() {
+
+  it('should exist', function() {
+    return expect(Backbone.Firebase.Model).to.be.ok;
+  });
+
+  it('should extend', function() {
+    var spy = sinon.spy();
+    var Model = Backbone.Firebase.Model.extend({
+      url: 'Mock://',
+      autoSync: false
+    });
+    return expect(Model).to.be.ok;
+  });
+
+});

--- a/test/specs/model_test.js
+++ b/test/specs/model_test.js
@@ -1,5 +1,7 @@
 describe('Backbone.Firebase.Model', function() {
 
+  MockFirebase.override();
+
   it('should exist', function() {
     return expect(Backbone.Firebase.Model).to.be.ok;
   });

--- a/test/specs/prototype_test.js
+++ b/test/specs/prototype_test.js
@@ -1,5 +1,7 @@
 describe('Backbone.Firebase', function() {
 
+  MockFirebase.override();
+
   it('should exist', function() {
     return expect(Backbone.Firebase).to.be.ok;
   });


### PR DESCRIPTION
This PR adds the feature of one-time sync vs realtime sync via the `autoSync` property.

``` javascript
var Todo = Backbone.Firebase.Model.extend({
  urlRoot: 'https://webapi.firebaseio.com/todos',
  autoSync: false
});

var todo = new Todo({
  id: 1
});

todo.set('name', 'David'); // not persisted
todo.save(); // is persisted
```

Resolves #74, #84, #85, #86, #89
