### PR TITLE
One time syncing for collections

### DIFF
--- a/test/specs/collection_test.js
+++ b/test/specs/collection_test.js
@@ -1,0 +1,17 @@
+describe('Backbone.Firebase.Collection', function() {
+
+  MockFirebase.override();
+
+  it('should exist', function() {
+    return expect(Backbone.Firebase.Collection).to.be.ok;
+  });
+
+  it('should extend', function() {
+    var spy = sinon.spy();
+    var Collection = Backbone.Firebase.Collection.extend({
+      url: 'Mock://'
+    });
+    return expect(Collection).to.be.ok;
+  });
+
+});


### PR DESCRIPTION
This PR adds the feature to have one time syncing for collections by setting autoSync to false.

``` javascript
var Todos = Backbone.Firebase.Collection.extend({
  url: 'https://backbone-firebase.firebaseio-demo.com/todos',
  autoSync: false
});

var model = todo.add({ title: 'One time persisting' }); // adds locally
model.save(); // persists to Firebase
```

Resolves #86, #91 
