### PR TITLE
Changed main in package.json and bower.json to unminified file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "realtime"
   ],
   "main": [
-    "dist/backfire.min.js"
+    "dist/backfire.js"
   ],
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "firebase",
     "realtime"
   ],
-  "main": "dist/backfire.min.js",
+  "main": "dist/backfire.js",
   "files": [
     "dist/**",
     "LICENSE",


### PR DESCRIPTION
@davideast - Please review and merge. After [much discussion and debate on this topic over on the AngularFire repo](https://github.com/firebase/angularfire/issues/436), I now believe we should be including the unminified files as `main` in the `package.json` and `bower.json`.
