### PR TITLE
Fixed broken README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BackFire
 
 [![Build Status](https://travis-ci.org/firebase/backfire.svg?branch=master)](https://travis-ci.org/firebase/backfire)
-[![Version](https://badge.fury.io/gh/firebase%2Fbackfire.svg)](http://badge.fury.io/gh/firebase%2Fbackfire)
+[![Version](https://badge.fury.io/gh/firebase%2Fbackfire.svg?branch=gh-pages)](http://badge.fury.io/gh/firebase%2Fbackfire)
 
 BackFire is the officially supported [Backbone](http://backbonejs.org) binding for
 [Firebase](http://www.firebase.com/?utm_medium=web&utm_source=backfire). The bindings let you use


### PR DESCRIPTION
@davideast - The README badge showed `?.?.?` instead of `0.3.0` because it kept trying to read from the `master` branch by default, but we use the `gh-pages` branch instead. I'd really like to rename the main branch as `master` to be consistent with our other repos. We would have to park [the demo](http://firebase.github.io/backfire/examples/todos/) on Firebase Hosting and update a few things in the README. Let's do this together next week.
