### PR TITLE
Throw error when syncing a primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,31 +3,47 @@
 [![Build Status](https://travis-ci.org/firebase/backfire.svg?branch=master)](https://travis-ci.org/firebase/backfire)
 [![Version](https://badge.fury.io/gh/firebase%2Fbackfire.svg)](http://badge.fury.io/gh/firebase%2Fbackfire)
 
-BackFire is the officially supported [Backbone](http://backbonejs.org) binding for
-[Firebase](http://www.firebase.com/?utm_medium=web&utm_source=backfire). The bindings let you use
-special model and collection types that will automatically synchronize with Firebase, and also
-allow you to use regular `Backbone.Sync` based synchronization methods.
-
+BackFire is the officially supported [Backbone](http://backbonejs.org) binding for Firebase. The bindings let you use special model and collection types that allow for synchronizing data with [Firebase](http://www.firebase.com/?utm_medium=web&utm_source=backfire).
 
 ## Live Demo
 
-Play around with our [realtime Todo App demo](http://firebase.github.io/backfire/examples/todos/)
-which was created using BackFire.
+Play around with our [realtime Todo App demo](https://backbonefire.firebaseapp.com/). This Todo App is a simple port of the TodoMVC app using Backfire.
+
+## Basic Usage
+
+```javascript
+var Todo = Backbone.Model.extend({
+  defaults: {
+    completed: false,
+    title: 'New todo'
+  }
+});
+var Todos = Backbone.Firebase.Collection.extend({
+  url: 'https://<your-firebase>.firebaseio.com/todos',
+  model: Todo
+});
+```
 
 
 ## Downloading BackFire
 
-In order to use BackFire in your project, you need to include the following files in your HTML:
+To get started include Firebase and Backfire after the usual Backbone dependencies (jQuery, Underscore, and Backbone).
 
 ```html
+<!-- jQuery -->
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+
+<!-- Underscore -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.7.0/underscore.js"></script>
+
 <!-- Backbone -->
-<script src="http://backbonejs.org/backbone-min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/backbone.js/1.1.2/backbone.js"></script>
 
 <!-- Firebase -->
-<script src="https://cdn.firebase.com/js/client/1.0.21/firebase.js"></script>
+<script src="https://cdn.firebase.com/js/client/2.0.3/firebase.js"></script>
 
 <!-- BackFire -->
-<script src="https://cdn.firebase.com/libs/backfire/0.3.0/backfire.min.js"></script>
+<script src="https://cdn.firebase.com/libs/backfire/0.5.0/backfire.js"></script>
 ```
 
 Use the URL above to download both the minified and non-minified versions of BackFire from the
@@ -42,8 +58,7 @@ You can also install BackFire via Bower and its dependencies will be downloaded 
 $ bower install backfire --save
 ```
 
-Once you've included BackFire and its dependencies into your project, you will have access to the
-`Backbone.Firebase`, `Backbone.Firebase.Collection`, and `Backbone.Firebase.Model` objects.
+Once you've included BackFire and its dependencies into your project, you will have access to the `Backbone.Firebase.Collection`, and `Backbone.Firebase.Model` objects.
 
 
 ## Getting Started with Firebase
@@ -51,76 +66,6 @@ Once you've included BackFire and its dependencies into your project, you will h
 BackFire requires Firebase in order to sync data. You can
 [sign up here](https://www.firebase.com/signup/?utm_medium=web&utm_source=backfire) for a free
 account.
-
-
-## Backbone.Firebase
-
-The bindings also override `Backbone.sync` to use Firebase. You may consider this option if you
-want to maintain an explicit seperation between _local_ and _remote_ data, and want to use regular
-Backbone models and collections.
-
-This adapter works very similarly to the
-[localStorage adapter](http://documentcloud.github.com/backbone/docs/backbone-localstorage.html)
-used in the canonical Todos example.
-
-Please see [todos-sync.js](https://github.com/firebase/backfire/blob/gh-pages/examples/todos/todos-sync.js)
-for an example of how to use this feature.
-
-### firebase
-
-You simply provide a `firebase` property in your collection, and that set of objects will be
-persisted at that location.
-
-```javascript
-var TodoList = Backbone.Collection.extend({
-  model: Todo,
-  firebase: new Backbone.Firebase("https://<your-firebase>.firebaseio.com")
-});
-```
-
-You can also do this with a model:
-
-```javascript
-var MyTodo = Backbone.Model.extend({
-  firebase: new Backbone.Firebase("https://<your-firebase>.firebaseio.com/myTodo")
-});
-```
-
-### fetch()
-
-In a collection with the `firebase` property defined, calling `fetch()` will retrieve data from
-Firebase and update the collection with its contents.
-
-```javascript
-TodoList.fetch();
-```
-
-### sync()
-
-In a collection with the `firebase` property defined, calling `sync()` will set the contents of the
-local collection to the specified Firebase location.
-
-```javascript
-TodoList.sync();
-```
-
-### save()
-
-In a model with the `firebase` property defined, calling `save()` will set the contents of the
-model to the specified Firebase location.
-
-```javascript
-MyTodo.save();
-```
-
-### destroy()
-
-In a model with the `firebase` property defined, calling `destroy()` will remove the contents at
-the specified Firebase location.
-
-```javascript
-MyTodo.destroy();
-```
 
 ## Backbone.Firebase.Collection
 

--- a/src/backfire.js
+++ b/src/backfire.js
@@ -477,7 +477,7 @@
         var model = snap.val();
         if (!model.id) {
           if (!_.isObject(model)) {
-            model = {};
+            Backbone.Firebase._throwError('InvalidIdException: Models must have an Id. Note: You may be trying to sync a primitive value (int, string, bool).');
           }
           model.id = snap.name();
         }
@@ -646,9 +646,10 @@
         SyncCollection.apply(this, arguments);
       }
 
-      // intercept the users model and give it a firebase ref
-      // and have it listen to local changes silently to set
-      // unsetted attributes to null to be deleted on the server
+      // Intercept the given model and give it a firebase ref.
+      // Have it listen to local changes silently. When attributes
+      // are unset, the callback will set them to null so that they
+      // are removed on the Firebase server.
       this.model = function(attrs, opts) {
 
         var newItem = new BaseModel(attrs, opts);

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -3,8 +3,8 @@ MockFirebase.override();
 function MockSnap(params) {
   params = params || {};
 
-  this._name = params.name || '';
-  this._val = params.val || '';
+  this._name = params.name;
+  this._val = params.val;
 
   this.name = function() {
     return this._name;

--- a/test/specs/collection_test.js
+++ b/test/specs/collection_test.js
@@ -147,13 +147,12 @@ describe('Backbone.Firebase.Collection', function() {
 
     it('should call setWithPriority on a Firebase reference', function() {
       collection._setWithPriority(collection.firebase, item);
-      collection.firebase.flush();
+      //collection.firebase.flush();
       expect(collection.firebase.setWithPriority.calledOnce).to.be.ok;
     });
 
     it('should delete local priority', function() {
       var setItem = collection._setWithPriority(collection.firebase, item);
-      collection.firebase.flush();
       expect(setItem['.priority']).to.be.undefined;
     });
 
@@ -167,7 +166,6 @@ describe('Backbone.Firebase.Collection', function() {
       });
       collection = new Collection();
       collection._updateToFirebase(collection.firebase, { id: '1' });
-      collection.firebase.flush();
       expect(collection.firebase.update.calledOnce).to.be.ok;
     });
 
@@ -263,27 +261,6 @@ describe('Backbone.Firebase.Collection', function() {
       models.firebase.flush();
       return expect(spy.called).to.be.ok;
     });
-
-    // it('should add an id to a new model', function() {
-    //
-    //   var mockSnap = new MockSnap({
-    //     name: '1',
-    //     val: {}
-    //   });
-    //
-    //   var Collection = Backbone.Firebase.Collection.extend({
-    //     url: 'Mock://',
-    //     autoSync: true
-    //   });
-    //
-    //   var collection = new Collection();
-    //
-    //   var model = collection._checkId(mockSnap);
-    //
-    //   expect(model.id).to.be.ok;
-    //   model.id.should.equal(mockSnap.name());
-    //
-    // });
 
     describe('#create', function() {
 
@@ -664,9 +641,9 @@ describe('Backbone.Firebase.Collection', function() {
       var collection;
       var model;
       beforeEach(function() {
+
         var Collection = Backbone.Firebase.Collection.extend({
-          url: 'Mock://',
-          autoSync: true
+          url: 'Mock://'
         });
 
         collection = new Collection();

--- a/test/specs/collection_test.js
+++ b/test/specs/collection_test.js
@@ -139,6 +139,7 @@ describe('Backbone.Firebase.Collection', function() {
 
       collection = new Collection();
       item = {
+        id: '1',
         '.priority': 1,
         name: 'David'
       }
@@ -162,8 +163,7 @@ describe('Backbone.Firebase.Collection', function() {
 
     it('should call update on a Firebase reference', function() {
       var Collection = Backbone.Firebase.Collection.extend({
-        url: 'Mock://',
-        autoSync: true
+        url: 'Mock://'
       });
       collection = new Collection();
       collection._updateToFirebase(collection.firebase, { id: '1' });
@@ -264,26 +264,26 @@ describe('Backbone.Firebase.Collection', function() {
       return expect(spy.called).to.be.ok;
     });
 
-    it('should add an id to a new model', function() {
-
-      var mockSnap = new MockSnap({
-        name: '1',
-        val: {}
-      });
-
-      var Collection = Backbone.Firebase.Collection.extend({
-        url: 'Mock://',
-        autoSync: true
-      });
-
-      var collection = new Collection();
-
-      var model = collection._checkId(mockSnap);
-
-      expect(model.id).to.be.ok;
-      model.id.should.equal(mockSnap.name());
-
-    });
+    // it('should add an id to a new model', function() {
+    //
+    //   var mockSnap = new MockSnap({
+    //     name: '1',
+    //     val: {}
+    //   });
+    //
+    //   var Collection = Backbone.Firebase.Collection.extend({
+    //     url: 'Mock://',
+    //     autoSync: true
+    //   });
+    //
+    //   var collection = new Collection();
+    //
+    //   var model = collection._checkId(mockSnap);
+    //
+    //   expect(model.id).to.be.ok;
+    //   model.id.should.equal(mockSnap.name());
+    //
+    // });
 
     describe('#create', function() {
 
@@ -484,6 +484,7 @@ describe('Backbone.Firebase.Collection', function() {
         var mockSnap = new MockSnap({
           name: '1',
           val: {
+            id: '1',
             name: 'David'
             // age has been removed
           }
@@ -502,6 +503,7 @@ describe('Backbone.Firebase.Collection', function() {
         var mockSnap = new MockSnap({
           name: '1',
           val: {
+            id: '1',
             name: 'David',
             age: 26,
             favDino: 'trex'

--- a/test/specs/model_test.js
+++ b/test/specs/model_test.js
@@ -116,7 +116,7 @@ describe('Backbone.Firebase.Model', function() {
 
       // create a mock snap that removes the 'lastName' property
       var mockSnap = new MockSnap({
-        name: 1,
+        name: '1',
         val: {
           firstName: 'David'
         }

--- a/test/specs/model_test.js
+++ b/test/specs/model_test.js
@@ -67,28 +67,6 @@ describe('Backbone.Firebase.Model', function() {
 
     });
 
-    it('should call _setToFirebase', function() {
-      sinon.spy(Backbone.Firebase, '_setToFirebase');
-
-      model.destroy();
-      model.firebase.flush();
-
-      expect(Backbone.Firebase._setToFirebase.calledOnce).to.be.ok;
-
-      Backbone.Firebase._setToFirebase.restore();
-    });
-
-    it('should call _onCompleteCheck', function() {
-      sinon.spy(Backbone.Firebase, '_onCompleteCheck');
-
-      model.destroy();
-      model.firebase.flush();
-
-      expect(Backbone.Firebase._onCompleteCheck.calledOnce).to.be.ok;
-
-      Backbone.Firebase._onCompleteCheck.restore();
-    });
-
   });
 
   it('should update model', function() {
@@ -129,12 +107,20 @@ describe('Backbone.Firebase.Model', function() {
 
     });
 
-    it('should set local', function() {
+    it('should call _unsetAttributes', function() {
       var Model = Backbone.Firebase.Model.extend({
         url: 'Mock://'
       });
+
       var model = new Model();
-      var mockSnap = new MockSnap();
+
+      var mockSnap = new MockSnap({
+        name: '1',
+        val: {
+          firstname: 'David'
+        }
+      });
+
       sinon.spy(model, '_unsetAttributes');
 
       model._setLocal(mockSnap);
@@ -148,7 +134,6 @@ describe('Backbone.Firebase.Model', function() {
 
   describe('#_setId', function() {
     it('should set id', function() {
-      // TODO: Test _setId
       var Model = Backbone.Firebase.Model.extend({
         url: 'Mock://'
       });
@@ -168,7 +153,7 @@ describe('Backbone.Firebase.Model', function() {
       });
       var model = new Model();
       var mockSnap = new MockSnap({
-        name: 1
+        name: '1'
       });
       model._setId(mockSnap);
 

--- a/test/specs/prototype_test.js
+++ b/test/specs/prototype_test.js
@@ -4,12 +4,44 @@ describe('Backbone.Firebase', function() {
     return expect(Backbone.Firebase).to.be.ok;
   });
 
+  describe("#_isPrimitive", function() {
+
+    it('should return false for null', function() {
+      var value = Backbone.Firebase._isPrimitive(null);
+      expect(value).to.be.false;
+    });
+
+    it('should return false for object', function() {
+      var value = Backbone.Firebase._isPrimitive({});
+      expect(value).to.be.false;
+    });
+
+    it('should return true for string', function() {
+      var value = Backbone.Firebase._isPrimitive('hello');
+      expect(value).to.be.true;
+    });
+
+    it('should return true for int', function() {
+      var value = Backbone.Firebase._isPrimitive(1);
+      expect(value).to.be.true;
+    });
+
+    it('should return true for bool', function() {
+      var value = Backbone.Firebase._isPrimitive(true);
+      expect(value).to.be.true;
+    });
+
+  });
+
   describe('#_checkId', function() {
+
     it('should add an id to a new model', function() {
 
       var mockSnap = new MockSnap({
         name: '1',
-        val: {}
+        val: {
+          firstname: 'David'
+        }
       });
 
       var model = Backbone.Firebase._checkId(mockSnap);
@@ -18,6 +50,29 @@ describe('Backbone.Firebase', function() {
       model.id.should.equal(mockSnap.name());
 
     });
+
+    it('should throw an error if the model is not an object', function() {
+      var mockSnap = new MockSnap({
+        name: '1',
+        val: 'hello'
+      });
+      try {
+        var model = Backbone.Firebase._checkId(1);
+      } catch (err) {
+        expect(err).to.be.ok
+      }
+
+    });
+
+    it('should create an object with an id for null values', function() {
+      var mockSnap = new MockSnap({
+        name: '1',
+        val: null
+      });
+      var model = Backbone.Firebase._checkId(mockSnap);
+      expect(model.id).to.be.ok;
+    });
+
   });
 
   describe('#_readOnce', function() {

--- a/test/specs/prototype_test.js
+++ b/test/specs/prototype_test.js
@@ -4,6 +4,22 @@ describe('Backbone.Firebase', function() {
     return expect(Backbone.Firebase).to.be.ok;
   });
 
+  describe('#_checkId', function() {
+    it('should add an id to a new model', function() {
+
+      var mockSnap = new MockSnap({
+        name: '1',
+        val: {}
+      });
+
+      var model = Backbone.Firebase._checkId(mockSnap);
+
+      expect(model.id).to.be.ok;
+      model.id.should.equal(mockSnap.name());
+
+    });
+  });
+
   describe('#_readOnce', function() {
 
     var ref;


### PR DESCRIPTION
This PR address the issue of syncing primitives. Backbone Models are meant to sync objects rather than primitives. If you attempt to sync a primitive an error will be thrown.
