### PR TITLE
Fixed 'this.firebase.child is not a function'

### DIFF
--- a/src/backbonefire.js
+++ b/src/backbonefire.js
@@ -571,7 +571,7 @@
         for (var i = 0; i < parsed.length; i++) {
           var model = parsed[i];
           // XXX model prototype broken: this.model.prototype.idAttribute worked around as this.idAttribute
-          var childRef = this.firebase.child(model[this.idAttribute]);
+          var childRef = this.firebase.ref().child(model[this.idAttribute]);
           if (options.silent === true) {
             this._suppressEvent = true;
           }


### PR DESCRIPTION
Just bumped into this error, `this.firebase.child is not a function` when trying to do a `collection.remove()` using backbonefire. Adding `.ref()` to this line fixes the problem (similar methods use `this.firebase.ref().child(...`).
