### PR TITLE
Fix Examples lanegoldberg@gmail.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ will be instantly updated.
 #### autoSync: true
 
 ```javascript
-var RealtimeModel = Backbone.Firebase.Model({
+var RealtimeModel = Backbone.Firebase.Model.extend({
   url: 'https://<your-firebase>.firebaseio.com/mytodo',
   autoSync: true // true by default
 });
@@ -264,7 +264,7 @@ realtimeModel.set('name', 'Bob');
 #### autoSync: false
 
 ```javascript
-var RealtimeModel = Backbone.Firebase.Model({
+var RealtimeModel = Backbone.Firebase.Model.extend({
   url: 'https://<your-firebase>.firebaseio.com/mytodo',
   autoSync: false
 });


### PR DESCRIPTION
missing the `extend` on the last two model examples.
